### PR TITLE
(Security) Fix to Passport local-login

### DIFF
--- a/server/middleware/passport.js
+++ b/server/middleware/passport.js
@@ -36,9 +36,11 @@ passport.use('local-signup', new LocalStrategy({
 },
   (req, email, password, done) => {
     // check to see if there is a local account with this email address
+    //check to see if there is an account with this id
     return models.Profile.where({ email }).fetch({
       withRelated: [{
-        auths: query => query.where({ type: 'local' })
+        // auths: query => query.where({ type: 'local' })
+        auths: query => query.where({ profile_id: req.user.id })
       }]
     })
       .then(profile => {

--- a/server/middleware/passport.js
+++ b/server/middleware/passport.js
@@ -35,12 +35,10 @@ passport.use('local-signup', new LocalStrategy({
   passReqToCallback: true
 },
   (req, email, password, done) => {
-    // check to see if there is a local account with this email address
     //check to see if there is an account with this id
     return models.Profile.where({ email }).fetch({
       withRelated: [{
-        // auths: query => query.where({ type: 'local' })
-        auths: query => query.where({ profile_id: req.user.id })
+        auths: query => query.where({ profile_id: undefined })
       }]
     })
       .then(profile => {

--- a/server/middleware/passport.js
+++ b/server/middleware/passport.js
@@ -35,22 +35,17 @@ passport.use('local-signup', new LocalStrategy({
   passReqToCallback: true
 },
   (req, email, password, done) => {
-    //check to see if there is an account with this id
-    return models.Profile.where({ email }).fetch({
-      withRelated: [{
-        auths: query => query.where({ profile_id: undefined })
-      }]
-    })
+    // check to see if there is an account with this id
+    return models.Profile.where({ email }).fetch(    )
       .then(profile => {
         // create a new profile if a profile does not exist
         if (!profile) {
           return models.Profile.forge({ first: req.body.first, email: email }).save();
         }
-        // throw if local auth account already exists
-        if (profile.related('auths').at(0)) {
+        // throw if any auth account already exists
+        if (profile) {
           throw profile;
         }
-
         return profile;
       })
       .tap(profile => {


### PR DESCRIPTION
Fixed an oversight between Passport OAuth and Passport local-signup.
Local-Signup after OAuth would create a second entry in database auth
table, potentially allowing for a user to use an unauthorized account.

This commit will patch this issue by changing what Passport looks for
when creating a new account